### PR TITLE
Add HPX

### DIFF
--- a/data/e4s_products.yaml
+++ b/data/e4s_products.yaml
@@ -42,6 +42,7 @@
 -  repo_url: https://github.com/ginkgo-project/ginkgo/blob/develop
 -  repo_url: https://bitbucket.hdfgroup.org/projects/HDFFV/repos/hdf5/browse
 -  repo_url: https://github.com/HPCToolkit/hpctoolkit/blob/master
+-  repo_url: https://github.com/STEllAR-GROUP/hpx/blob/master
 -  repo_url: https://github.com/hypre-space/hypre/blob/master
 -  repo_url: https://github.com/kokkos/kokkos/blob/master
 -  repo_url: https://github.com/kokkos/kokkos-kernels/blob/master

--- a/data/hpx/e4s.yaml
+++ b/data/hpx/e4s.yaml
@@ -1,0 +1,6 @@
+- e4s_product: hpx
+  Docs: [README.rst, LICENSE_1_0.txt]
+  Area: "PMR"
+  Description: "The C++ Standard Library for Parallelism and Concurrency."
+  Website: https://hpx.stellar-group.org/
+  MemberProduct: False


### PR DESCRIPTION
I accidentally found out that HPX has now been added to the level 0 of e4s, i.e. being listed as a spack package for it. I'm very happy to see that, thank you! I'm hoping this is the correct next step. I know we don't fulfill all the level 2 criteria yet (in particular P2), so I've set `MemberProduct` to `false`.

I'm curious: I've asked about having HPX included before, but I've been bad at following up on it. Was the addition requested by someone outside the HPX developers or was it just added because of my earlier requests for it?